### PR TITLE
Qt5 based menu bar not visible by default on Ubuntu using awesome WM

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -470,6 +470,8 @@ void VisualizationFrame::initMenus()
   help_menu->addAction( "Open rviz wiki in browser", this, SLOT( onHelpWiki() ));
   help_menu->addSeparator();
   help_menu->addAction( "&About", this, SLOT( onHelpAbout() ));
+  
+  menuBar()->setVisible(true);
 }
 
 void VisualizationFrame::initToolbars()


### PR DESCRIPTION
I noticed when compiling rviz with Qt5 the menu bar is not visible by default on ubuntu at least with awesome WM.
A portable fix is setting the visibility of the menu bar explicitly. This fixes the issue.